### PR TITLE
Refactor pointer handling

### DIFF
--- a/examples/contract_get_needed_txs.c
+++ b/examples/contract_get_needed_txs.c
@@ -31,24 +31,23 @@ int main() {
     rgb_debug_print_contract(&contract);
 
     // TODO: needed_txs should be freed
-    struct rgb_needed_tx *needed_txs = NULL;
-    uint32_t len = rgb_contract_get_needed_txs(&contract, &needed_txs);
+    struct rgb_allocated_rgb_needed_tx needed_txs = rgb_contract_get_needed_txs(&contract);
 
-    printf("Number of elements: %u\n", len);
+    printf("Number of elements: %lu\n", needed_txs.len);
 
-    for (size_t i = 0; i < len; ++i) {
-        if (needed_txs[i].type == RGB_NEEDED_TX_TXID) {
+    for (size_t i = 0; i < needed_txs.len; ++i) {
+        if (needed_txs.ptr[i].type == RGB_NEEDED_TX_TXID) {
             printf("FromTXID(\n\ttxid: ");
-            print_hex((void *) &needed_txs[i].txid, 32);
+            print_hex((void *) &needed_txs.ptr[i].txid, 32);
             printf("\n)\n");
 
-        } else if (needed_txs[i].type == RGB_NEEDED_TX_SPENDS_OUTPOINT) {
+        } else if (needed_txs.ptr[i].type == RGB_NEEDED_TX_SPENDS_OUTPOINT) {
             printf("WhichSpendsOutPoint(\n\ttxid: ");
-            print_hex((void *) &needed_txs[i].outpoint.txid, 32);
-            printf("\n\tvout: %u\n)\n", needed_txs[i].outpoint.vout);
+            print_hex((void *) &needed_txs.ptr[i].outpoint.txid, 32);
+            printf("\n\tvout: %u\n)\n", needed_txs.ptr[i].outpoint.vout);
 
         } else {
-            fprintf(stderr, "Unknown NeededTx type %u. Exiting now.\n", needed_txs->type);
+            fprintf(stderr, "Unknown NeededTx type %u. Exiting now.\n", needed_txs.ptr[i].type);
 
             return EXIT_FAILURE;
         }

--- a/examples/contract_get_needed_txs.c
+++ b/examples/contract_get_needed_txs.c
@@ -31,7 +31,7 @@ int main() {
     rgb_debug_print_contract(&contract);
 
     // TODO: needed_txs should be freed
-    struct rgb_allocated_rgb_needed_tx needed_txs = rgb_contract_get_needed_txs(&contract);
+    struct rgb_allocated_array_rgb_needed_tx needed_txs = rgb_contract_get_needed_txs(&contract);
 
     printf("Number of elements: %lu\n", needed_txs.len);
 

--- a/examples/contract_get_needed_txs.c
+++ b/examples/contract_get_needed_txs.c
@@ -30,7 +30,6 @@ int main() {
 
     rgb_debug_print_contract(&contract);
 
-    // TODO: needed_txs should be freed
     struct rgb_allocated_array_rgb_needed_tx needed_txs = rgb_contract_get_needed_txs(&contract);
 
     printf("Number of elements: %lu\n", needed_txs.len);
@@ -52,6 +51,9 @@ int main() {
             return EXIT_FAILURE;
         }
     }
+
+    rgb_free_array(needed_txs,
+    struct rgb_allocated_array_rgb_needed_tx);
 
     return EXIT_SUCCESS;
 }

--- a/examples/create_contract.c
+++ b/examples/create_contract.c
@@ -32,42 +32,38 @@ int main() {
 
     rgb_debug_print_contract(&contract);
 
-    struct rgb_sha256d asset_id;
-
-    rgb_contract_get_asset_id(&contract, &asset_id);
+    struct rgb_sha256d *asset_id = rgb_as_ptr(rgb_contract_get_asset_id(&contract));
 
     printf("From Rust: ");
     fflush(stdout); // without this the order of prints would likely be messed up
-    rgb_debug_sha256d(&asset_id);
+    rgb_debug_sha256d(asset_id);
 
     printf("From C:    ");
-    print_hex((const void *) &asset_id, 32);
+    print_hex((const void *) asset_id, 32);
 
     printf("\n");
 
     // Let's ask Rust for the commitment script
-    uint8_t *script_buffer = NULL;
-    uint32_t script_len = rgb_contract_get_expected_script(&contract, &script_buffer);
+    struct rgb_allocated_uint8_t script = rgb_contract_get_expected_script(&contract);
 
     printf("Expected commitment output: ");
-    print_hex((const void *) script_buffer, script_len);
+    print_hex((const void *) script.ptr, script.size);
 
     printf("\n");
 
     // And now we serialize it
-    uint8_t *serialized_buffer = NULL;
-    uint32_t serialized_len = rgb_contract_serialize(&contract, &serialized_buffer);
+    struct rgb_allocated_uint8_t serialized_contract = rgb_contract_serialize(&contract);
 
     printf("Serialized contract: ");
-    print_hex((const void *) serialized_buffer, serialized_len);
+    print_hex((const void *) serialized_contract.ptr, serialized_contract.size);
 
     printf("\n");
 
     // And deserialize it
-    struct rgb_contract deserialized_contract;
-    rgb_contract_deserialize(serialized_buffer, serialized_len, &deserialized_contract);
+    struct rgb_contract *deserialized_contract = rgb_as_ptr(
+	    rgb_contract_deserialize(serialized_contract.ptr, serialized_contract.size));
 
-    rgb_debug_print_contract(&deserialized_contract);
+    rgb_debug_print_contract(deserialized_contract);
 
     return EXIT_SUCCESS;
 }

--- a/examples/create_contract.c
+++ b/examples/create_contract.c
@@ -65,5 +65,14 @@ int main() {
 
     rgb_debug_print_contract(deserialized_contract);
 
+    rgb_free(asset_id,
+    struct rgb_sha256d);
+    rgb_free(deserialized_contract,
+    struct rgb_contract);
+    rgb_free_array(script,
+    struct rgb_allocated_array_uint8_t);
+    rgb_free_array(serialized_contract,
+    struct rgb_allocated_array_uint8_t);
+
     return EXIT_SUCCESS;
 }

--- a/examples/create_contract.c
+++ b/examples/create_contract.c
@@ -32,7 +32,7 @@ int main() {
 
     rgb_debug_print_contract(&contract);
 
-    struct rgb_sha256d *asset_id = rgb_as_ptr(rgb_contract_get_asset_id(&contract));
+    struct rgb_sha256d *asset_id = rgb_contract_get_asset_id(&contract);
 
     printf("From Rust: ");
     fflush(stdout); // without this the order of prints would likely be messed up
@@ -60,8 +60,8 @@ int main() {
     printf("\n");
 
     // And deserialize it
-    struct rgb_contract *deserialized_contract = rgb_as_ptr(
-	    rgb_contract_deserialize(serialized_contract.ptr, serialized_contract.size));
+    struct rgb_contract *deserialized_contract = rgb_contract_deserialize(serialized_contract.ptr,
+									  serialized_contract.size);
 
     rgb_debug_print_contract(deserialized_contract);
 

--- a/examples/create_contract.c
+++ b/examples/create_contract.c
@@ -44,7 +44,7 @@ int main() {
     printf("\n");
 
     // Let's ask Rust for the commitment script
-    struct rgb_allocated_uint8_t script = rgb_contract_get_expected_script(&contract);
+    struct rgb_allocated_array_uint8_t script = rgb_contract_get_expected_script(&contract);
 
     printf("Expected commitment output: ");
     print_hex((const void *) script.ptr, script.size);
@@ -52,7 +52,7 @@ int main() {
     printf("\n");
 
     // And now we serialize it
-    struct rgb_allocated_uint8_t serialized_contract = rgb_contract_serialize(&contract);
+    struct rgb_allocated_array_uint8_t serialized_contract = rgb_contract_serialize(&contract);
 
     printf("Serialized contract: ");
     print_hex((const void *) serialized_contract.ptr, serialized_contract.size);

--- a/examples/create_proof.c
+++ b/examples/create_proof.c
@@ -46,7 +46,7 @@ int main() {
 
     rgb_debug_print_proof(&proof);
 
-    struct rgb_allocated_uint8_t serialized_proof = rgb_proof_serialize(&proof);
+    struct rgb_allocated_array_uint8_t serialized_proof = rgb_proof_serialize(&proof);
 
     printf("Proof (hex): ");
     print_hex(serialized_proof.ptr, serialized_proof.size);

--- a/examples/create_proof.c
+++ b/examples/create_proof.c
@@ -26,7 +26,7 @@ int main() {
             .total_supply = 1000
     };
 
-    struct rgb_sha256d *asset_id = rgb_as_ptr(rgb_contract_get_asset_id(&contract));
+    struct rgb_sha256d *asset_id = rgb_contract_get_asset_id(&contract);
 
     struct rgb_output_entry entry = {
             .asset_id = *asset_id,
@@ -51,8 +51,7 @@ int main() {
     printf("Proof (hex): ");
     print_hex(serialized_proof.ptr, serialized_proof.size);
 
-    struct rgb_proof *deserialized_proof = rgb_as_ptr(
-            rgb_proof_deserialize(serialized_proof.ptr, serialized_proof.size));
+    struct rgb_proof *deserialized_proof = rgb_proof_deserialize(serialized_proof.ptr, serialized_proof.size);
 
     rgb_debug_print_proof(deserialized_proof);
 

--- a/examples/create_proof.c
+++ b/examples/create_proof.c
@@ -55,5 +55,12 @@ int main() {
 
     rgb_debug_print_proof(deserialized_proof);
 
+    rgb_free(asset_id,
+    struct rgb_sha256d);
+    rgb_free(deserialized_proof,
+    struct rgb_proof);
+    rgb_free_array(serialized_proof,
+    struct rgb_allocated_array_uint8_t);
+
     return EXIT_SUCCESS;
 }

--- a/examples/create_proof.c
+++ b/examples/create_proof.c
@@ -26,11 +26,10 @@ int main() {
             .total_supply = 1000
     };
 
-    struct rgb_sha256d asset_id;
-    rgb_contract_get_asset_id(&contract, &asset_id);
+    struct rgb_sha256d *asset_id = rgb_as_ptr(rgb_contract_get_asset_id(&contract));
 
     struct rgb_output_entry entry = {
-            .asset_id = asset_id,
+            .asset_id = *asset_id,
             .amount = contract.total_supply,
             .vout = 0
     };
@@ -47,21 +46,15 @@ int main() {
 
     rgb_debug_print_proof(&proof);
 
-    uint32_t size = rgb_proof_get_serialized_size(&proof);
-
-    uint8_t *buffer = malloc(size);
-    uint32_t size_2 = rgb_proof_serialize(&proof, &buffer);
-
-    assert(size == size_2);
+    struct rgb_allocated_uint8_t serialized_proof = rgb_proof_serialize(&proof);
 
     printf("Proof (hex): ");
-    print_hex(buffer, size);
+    print_hex(serialized_proof.ptr, serialized_proof.size);
 
-    struct rgb_proof deserialized_proof;
+    struct rgb_proof *deserialized_proof = rgb_as_ptr(
+            rgb_proof_deserialize(serialized_proof.ptr, serialized_proof.size));
 
-    rgb_proof_deserialize(buffer, size, &deserialized_proof);
-
-    rgb_debug_print_proof(&deserialized_proof);
+    rgb_debug_print_proof(deserialized_proof);
 
     return EXIT_SUCCESS;
 }

--- a/examples/verify_contract.c
+++ b/examples/verify_contract.c
@@ -65,5 +65,8 @@ int main() {
 
     printf("Verification result: %u\n", result);
 
+    rgb_free(map,
+    struct rgb_needed_tx_map);
+
     return EXIT_SUCCESS;
 }

--- a/examples/verify_contract.c
+++ b/examples/verify_contract.c
@@ -57,9 +57,7 @@ int main() {
 
     decode_hex(hex, tx.payload, sizeof(hex) / 2);
 
-    struct rgb_needed_tx_map *map;
-
-    rgb_init_needed_tx_map(&map);
+    struct rgb_needed_tx_map *map = rgb_as_ptr(rgb_init_needed_tx_map());
     rgb_push_needed_tx_map(map, &need, &tx);
 
     // The check will fail with "invalid commitment"

--- a/examples/verify_contract.c
+++ b/examples/verify_contract.c
@@ -57,7 +57,7 @@ int main() {
 
     decode_hex(hex, tx.payload, sizeof(hex) / 2);
 
-    struct rgb_needed_tx_map *map = rgb_as_ptr(rgb_init_needed_tx_map());
+    struct rgb_needed_tx_map *map = rgb_init_needed_tx_map();
     rgb_push_needed_tx_map(map, &need, &tx);
 
     // The check will fail with "invalid commitment"

--- a/include/rgb.h
+++ b/include/rgb.h
@@ -20,6 +20,13 @@ struct rgb_sha256d {
 struct rgb_needed_tx_map {
 };
 
+#define _typecheck(type, x) \
+({  type __rgb_free_typechecker; \
+    typeof(x) __dummy; \
+    (void)(&__rgb_free_typechecker == &__dummy); \
+    1; \
+})
+
 #define _declare_rgb_allocated_array_internal(type, optional_struct)        \
         struct rgb_allocated_array_ ## type {                                \
             optional_struct type *ptr;                                        \
@@ -40,6 +47,13 @@ declare_rgb_allocated_array_struct(rgb_needed_tx)
 declare_rgb_allocated_array_struct(rgb_needed_tx_map)
 declare_rgb_allocated_array_struct(rgb_sha256d)
 declare_rgb_allocated_array_native(uint8_t)
+
+void _rgb_free_internal_struct(void *ptr, char *type);
+
+void _rgb_free_internal_array(void *ptr, char *type);
+
+#define rgb_free(ptr, type) (_typecheck(type, *ptr), _rgb_free_internal_struct(ptr, #type))
+#define rgb_free_array(arr, type) (_typecheck(type, arr), _rgb_free_internal_array(&arr, #type))
 
 struct rgb_bitcoin_outpoint {
     struct rgb_sha256d txid;

--- a/include/rgb.h
+++ b/include/rgb.h
@@ -22,8 +22,8 @@ struct rgb_needed_tx_map {
 
 #define rgb_as_ptr(x) (x).ptr
 
-#define _declare_rgb_allocated_box_internal(type, optional_struct)        \
-        struct rgb_allocated_ ## type {                                \
+#define _declare_rgb_allocated_array_internal(type, optional_struct)        \
+        struct rgb_allocated_array_ ## type {                                \
             optional_struct type *ptr;                                        \
             union {                                                        \
                 size_t len;                                                \
@@ -32,16 +32,16 @@ struct rgb_needed_tx_map {
             };                                                                \
         };
 
-#define declare_rgb_allocated_box_struct(type) _declare_rgb_allocated_box_internal(type, struct)
-#define declare_rgb_allocated_box_native(type) _declare_rgb_allocated_box_internal(type,)
+#define declare_rgb_allocated_array_struct(type) _declare_rgb_allocated_array_internal(type, struct)
+#define declare_rgb_allocated_array_native(type) _declare_rgb_allocated_array_internal(type,)
 
 // Declare all the possible boxes being returned
-declare_rgb_allocated_box_struct(rgb_contract)
-declare_rgb_allocated_box_struct(rgb_proof)
-declare_rgb_allocated_box_struct(rgb_needed_tx)
-declare_rgb_allocated_box_struct(rgb_needed_tx_map)
-declare_rgb_allocated_box_struct(rgb_sha256d)
-declare_rgb_allocated_box_native(uint8_t)
+declare_rgb_allocated_array_struct(rgb_contract)
+declare_rgb_allocated_array_struct(rgb_proof)
+declare_rgb_allocated_array_struct(rgb_needed_tx)
+declare_rgb_allocated_array_struct(rgb_needed_tx_map)
+declare_rgb_allocated_array_struct(rgb_sha256d)
+declare_rgb_allocated_array_native(uint8_t)
 
 struct rgb_bitcoin_outpoint {
     struct rgb_sha256d txid;
@@ -80,19 +80,19 @@ struct rgb_contract {
     uint32_t total_supply;
 };
 
-struct rgb_allocated_rgb_sha256d rgb_contract_get_asset_id(const struct rgb_contract *contract);
+struct rgb_allocated_array_rgb_sha256d rgb_contract_get_asset_id(const struct rgb_contract *contract);
 
-struct rgb_allocated_rgb_needed_tx rgb_contract_get_needed_txs(const struct rgb_contract *contract);
+struct rgb_allocated_array_rgb_needed_tx rgb_contract_get_needed_txs(const struct rgb_contract *contract);
 
-struct rgb_allocated_uint8_t rgb_contract_get_expected_script(const struct rgb_contract *contract);
+struct rgb_allocated_array_uint8_t rgb_contract_get_expected_script(const struct rgb_contract *contract);
 
-struct rgb_allocated_uint8_t rgb_contract_serialize(const struct rgb_contract *contract);
+struct rgb_allocated_array_uint8_t rgb_contract_serialize(const struct rgb_contract *contract);
 
-struct rgb_allocated_rgb_contract rgb_contract_deserialize(const uint8_t *buffer, uint32_t len);
+struct rgb_allocated_array_rgb_contract rgb_contract_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_contract_verify(const struct rgb_contract *contract, const struct rgb_needed_tx_map *map);
 
-struct rgb_allocated_rgb_needed_tx_map rgb_init_needed_tx_map();
+struct rgb_allocated_array_rgb_needed_tx_map rgb_init_needed_tx_map();
 
 void rgb_push_needed_tx_map(struct rgb_needed_tx_map *map, const struct rgb_needed_tx *key,
                             const struct rgb_bitcoin_serialized_tx *val);
@@ -111,17 +111,17 @@ struct rgb_proof {
 
 uint8_t rgb_proof_is_root_proof(const struct rgb_proof *proof);
 
-struct rgb_allocated_rgb_needed_tx rgb_proof_get_needed_txs(const struct rgb_proof *proof);
+struct rgb_allocated_array_rgb_needed_tx rgb_proof_get_needed_txs(const struct rgb_proof *proof);
 
-struct rgb_allocated_uint8_t rgb_proof_get_expected_script(const struct rgb_proof *proof);
+struct rgb_allocated_array_uint8_t rgb_proof_get_expected_script(const struct rgb_proof *proof);
 
-struct rgb_allocated_uint8_t rgb_proof_serialize(const struct rgb_proof *proof);
+struct rgb_allocated_array_uint8_t rgb_proof_serialize(const struct rgb_proof *proof);
 
-struct rgb_allocated_rgb_proof rgb_proof_deserialize(const uint8_t *buffer, uint32_t len);
+struct rgb_allocated_array_rgb_proof rgb_proof_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_proof_verify(const struct rgb_proof *proof, const struct rgb_needed_tx_map *map);
 
-struct rgb_allocated_rgb_contract
+struct rgb_allocated_array_rgb_contract
 rgb_proof_get_contract_for(const struct rgb_proof *proof, const struct rgb_sha256d *asset_id); // TODO!
 
 // Debug functions

--- a/include/rgb.h
+++ b/include/rgb.h
@@ -20,6 +20,29 @@ struct rgb_sha256d {
 struct rgb_needed_tx_map {
 };
 
+#define rgb_as_ptr(x) (x).ptr
+
+#define _declare_rgb_allocated_box_internal(type, optional_struct)        \
+        struct rgb_allocated_ ## type {                                \
+            optional_struct type *ptr;                                        \
+            union {                                                        \
+                size_t len;                                                \
+                size_t size;                                                \
+                size_t num_elements;                                        \
+            };                                                                \
+        };
+
+#define declare_rgb_allocated_box_struct(type) _declare_rgb_allocated_box_internal(type, struct)
+#define declare_rgb_allocated_box_native(type) _declare_rgb_allocated_box_internal(type,)
+
+// Declare all the possible boxes being returned
+declare_rgb_allocated_box_struct(rgb_contract)
+declare_rgb_allocated_box_struct(rgb_proof)
+declare_rgb_allocated_box_struct(rgb_needed_tx)
+declare_rgb_allocated_box_struct(rgb_needed_tx_map)
+declare_rgb_allocated_box_struct(rgb_sha256d)
+declare_rgb_allocated_box_native(uint8_t)
+
 struct rgb_bitcoin_outpoint {
     struct rgb_sha256d txid;
     uint32_t vout;
@@ -57,19 +80,19 @@ struct rgb_contract {
     uint32_t total_supply;
 };
 
-void rgb_contract_get_asset_id(const struct rgb_contract *contract, struct rgb_sha256d *hash_buffer);
+struct rgb_allocated_rgb_sha256d rgb_contract_get_asset_id(const struct rgb_contract *contract);
 
-uint32_t rgb_contract_get_needed_txs(const struct rgb_contract *contract, struct rgb_needed_tx **needed_txs);
+struct rgb_allocated_rgb_needed_tx rgb_contract_get_needed_txs(const struct rgb_contract *contract);
 
-uint32_t rgb_contract_get_expected_script(const struct rgb_contract *contract, uint8_t **buffer);
+struct rgb_allocated_uint8_t rgb_contract_get_expected_script(const struct rgb_contract *contract);
 
-uint32_t rgb_contract_serialize(const struct rgb_contract *contract, uint8_t **buffer);
+struct rgb_allocated_uint8_t rgb_contract_serialize(const struct rgb_contract *contract);
 
-void rgb_contract_deserialize(const uint8_t *buffer, uint32_t len, struct rgb_contract *contract);
+struct rgb_allocated_rgb_contract rgb_contract_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_contract_verify(const struct rgb_contract *contract, const struct rgb_needed_tx_map *map);
 
-void rgb_init_needed_tx_map(struct rgb_needed_tx_map **map);
+struct rgb_allocated_rgb_needed_tx_map rgb_init_needed_tx_map();
 
 void rgb_push_needed_tx_map(struct rgb_needed_tx_map *map, const struct rgb_needed_tx *key,
                             const struct rgb_bitcoin_serialized_tx *val);
@@ -88,20 +111,18 @@ struct rgb_proof {
 
 uint8_t rgb_proof_is_root_proof(const struct rgb_proof *proof);
 
-uint32_t rgb_proof_get_needed_txs(const struct rgb_proof *proof, struct rgb_needed_tx **needed_txs);
+struct rgb_allocated_rgb_needed_tx rgb_proof_get_needed_txs(const struct rgb_proof *proof);
 
-uint32_t rgb_proof_get_expected_script(const struct rgb_proof *proof, uint8_t **buffer);
+struct rgb_allocated_uint8_t rgb_proof_get_expected_script(const struct rgb_proof *proof);
 
-uint32_t rgb_proof_get_serialized_size(const struct rgb_proof *proof);
+struct rgb_allocated_uint8_t rgb_proof_serialize(const struct rgb_proof *proof);
 
-uint32_t rgb_proof_serialize(const struct rgb_proof *proof, uint8_t **buffer);
-
-void rgb_proof_deserialize(const uint8_t *buffer, uint32_t len, struct rgb_proof *proof);
+struct rgb_allocated_rgb_proof rgb_proof_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_proof_verify(const struct rgb_proof *proof, const struct rgb_needed_tx_map *map);
 
-uint8_t rgb_proof_get_contract_for(const struct rgb_proof *proof, const struct rgb_sha256d *asset_id,
-                                   struct rgb_contract **contract);
+struct rgb_allocated_rgb_contract
+rgb_proof_get_contract_for(const struct rgb_proof *proof, const struct rgb_sha256d *asset_id); // TODO!
 
 // Debug functions
 

--- a/include/rgb.h
+++ b/include/rgb.h
@@ -20,8 +20,6 @@ struct rgb_sha256d {
 struct rgb_needed_tx_map {
 };
 
-#define rgb_as_ptr(x) (x).ptr
-
 #define _declare_rgb_allocated_array_internal(type, optional_struct)        \
         struct rgb_allocated_array_ ## type {                                \
             optional_struct type *ptr;                                        \
@@ -80,7 +78,7 @@ struct rgb_contract {
     uint32_t total_supply;
 };
 
-struct rgb_allocated_array_rgb_sha256d rgb_contract_get_asset_id(const struct rgb_contract *contract);
+struct rgb_sha256d *rgb_contract_get_asset_id(const struct rgb_contract *contract);
 
 struct rgb_allocated_array_rgb_needed_tx rgb_contract_get_needed_txs(const struct rgb_contract *contract);
 
@@ -88,11 +86,11 @@ struct rgb_allocated_array_uint8_t rgb_contract_get_expected_script(const struct
 
 struct rgb_allocated_array_uint8_t rgb_contract_serialize(const struct rgb_contract *contract);
 
-struct rgb_allocated_array_rgb_contract rgb_contract_deserialize(const uint8_t *buffer, uint32_t len);
+struct rgb_contract *rgb_contract_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_contract_verify(const struct rgb_contract *contract, const struct rgb_needed_tx_map *map);
 
-struct rgb_allocated_array_rgb_needed_tx_map rgb_init_needed_tx_map();
+struct rgb_needed_tx_map *rgb_init_needed_tx_map();
 
 void rgb_push_needed_tx_map(struct rgb_needed_tx_map *map, const struct rgb_needed_tx *key,
                             const struct rgb_bitcoin_serialized_tx *val);
@@ -117,11 +115,11 @@ struct rgb_allocated_array_uint8_t rgb_proof_get_expected_script(const struct rg
 
 struct rgb_allocated_array_uint8_t rgb_proof_serialize(const struct rgb_proof *proof);
 
-struct rgb_allocated_array_rgb_proof rgb_proof_deserialize(const uint8_t *buffer, uint32_t len);
+struct rgb_proof *rgb_proof_deserialize(const uint8_t *buffer, uint32_t len);
 
 uint8_t rgb_proof_verify(const struct rgb_proof *proof, const struct rgb_needed_tx_map *map);
 
-struct rgb_allocated_array_rgb_contract
+struct rgb_contract *
 rgb_proof_get_contract_for(const struct rgb_proof *proof, const struct rgb_sha256d *asset_id); // TODO!
 
 // Debug functions

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -11,9 +11,9 @@ use rgb::traits::NeededTx;
 use rgb::traits::Verify;
 
 use ::{CRgbAllocatedArray, libc};
+use ::{CRgbAllocatedPtr, CRgbNeededTx};
 use c_bitcoin::CRgbBitcoinNetwork;
 use c_bitcoin::CRgbOutPoint;
-use CRgbNeededTx;
 use generics::WrapperOf;
 
 //#[derive(Debug)]
@@ -61,9 +61,9 @@ impl WrapperOf<Contract> for CRgbContract {
 // Contracts
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_get_asset_id(contract: &CRgbContract) -> CRgbAllocatedArray<Sha256dHash> {
-    CRgbAllocatedArray {
-        ptr: vec![contract.decode().get_asset_id()].into_boxed_slice()
+pub extern "C" fn rgb_contract_get_asset_id(contract: &CRgbContract) -> CRgbAllocatedPtr<Sha256dHash> {
+    CRgbAllocatedPtr {
+        ptr: Box::new([contract.decode().get_asset_id()])
     }
 }
 
@@ -112,7 +112,7 @@ pub extern "C" fn rgb_contract_serialize(contract: &CRgbContract) -> CRgbAllocat
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbAllocatedArray<CRgbContract> {
+pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbAllocatedPtr<CRgbContract> {
     use bitcoin::network::serialize::deserialize;
 
     let sized_slice = unsafe { slice::from_raw_parts(buffer, len as usize) };
@@ -121,8 +121,8 @@ pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbA
 
     let native_contract = deserialize(&encoded).unwrap();
 
-    CRgbAllocatedArray {
-        ptr: vec![CRgbContract::encode(&native_contract)].into_boxed_slice()
+    CRgbAllocatedPtr {
+        ptr: Box::new([CRgbContract::encode(&native_contract)])
     }
 }
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -10,7 +10,7 @@ use rgb::contract::Contract;
 use rgb::traits::NeededTx;
 use rgb::traits::Verify;
 
-use ::{CRgbAllocatedBox, libc};
+use ::{CRgbAllocatedArray, libc};
 use c_bitcoin::CRgbBitcoinNetwork;
 use c_bitcoin::CRgbOutPoint;
 use CRgbNeededTx;
@@ -61,27 +61,27 @@ impl WrapperOf<Contract> for CRgbContract {
 // Contracts
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_get_asset_id(contract: &CRgbContract) -> CRgbAllocatedBox<Sha256dHash> {
-    CRgbAllocatedBox {
+pub extern "C" fn rgb_contract_get_asset_id(contract: &CRgbContract) -> CRgbAllocatedArray<Sha256dHash> {
+    CRgbAllocatedArray {
         ptr: vec![contract.decode().get_asset_id()].into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_get_needed_txs(contract: &CRgbContract) -> CRgbAllocatedBox<CRgbNeededTx> {
+pub extern "C" fn rgb_contract_get_needed_txs(contract: &CRgbContract) -> CRgbAllocatedArray<CRgbNeededTx> {
     let needed_txs_native = contract.decode().get_needed_txs();
     let needed_txs_vec: Vec<CRgbNeededTx> = needed_txs_native
         .iter()
         .map(|ref x| CRgbNeededTx::encode(x))
         .collect();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: needed_txs_vec.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_get_expected_script(contract: &CRgbContract) -> CRgbAllocatedBox<u8> {
+pub extern "C" fn rgb_contract_get_expected_script(contract: &CRgbContract) -> CRgbAllocatedArray<u8> {
     use bitcoin::network::serialize::serialize;
 
     let script = contract.decode().get_expected_script();
@@ -95,24 +95,24 @@ pub extern "C" fn rgb_contract_get_expected_script(contract: &CRgbContract) -> C
        field will remain */
     encoded.remove(0);
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: encoded.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_serialize(contract: &CRgbContract) -> CRgbAllocatedBox<u8> {
+pub extern "C" fn rgb_contract_serialize(contract: &CRgbContract) -> CRgbAllocatedArray<u8> {
     use bitcoin::network::serialize::serialize;
 
     let encoded: Vec<u8> = serialize(&contract.decode()).unwrap();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: encoded.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbAllocatedBox<CRgbContract> {
+pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbAllocatedArray<CRgbContract> {
     use bitcoin::network::serialize::deserialize;
 
     let sized_slice = unsafe { slice::from_raw_parts(buffer, len as usize) };
@@ -121,7 +121,7 @@ pub extern "C" fn rgb_contract_deserialize(buffer: *const u8, len: u32) -> CRgbA
 
     let native_contract = deserialize(&encoded).unwrap();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: vec![CRgbContract::encode(&native_contract)].into_boxed_slice()
     }
 }

--- a/src/free.rs
+++ b/src/free.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::ptr;
+
+use bitcoin::Transaction;
+use bitcoin::util::hash::Sha256dHash;
+use rgb::traits::NeededTx;
+
+use ::{CRgbNeededTx, libc};
+use contract::CRgbContract;
+use CRgbAllocatedArray;
+use proof::CRgbProof;
+
+unsafe fn rust_drop_ptr<T>(ptr: *mut libc::c_void) {
+    ptr::drop_in_place(ptr as *mut T);
+}
+
+unsafe fn rust_drop_array<T>(arr: *mut libc::c_void) {
+    ptr::drop_in_place(arr as *mut CRgbAllocatedArray<T>);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn _rgb_free_internal_struct(ptr: *mut libc::c_void, type_str: *const libc::c_char) {
+    let type_str = CStr::from_ptr(type_str).to_str().unwrap();
+
+    match type_str {
+        "struct rgb_contract" => rust_drop_ptr::<CRgbContract>(ptr),
+        "struct rgb_proof" => rust_drop_ptr::<CRgbProof>(ptr),
+        "struct rgb_needed_tx" => rust_drop_ptr::<CRgbNeededTx>(ptr),
+        "struct rgb_needed_tx_map" => rust_drop_ptr::<HashMap<NeededTx, Transaction>>(ptr),
+        "struct rgb_sha256d" => rust_drop_ptr::<Sha256dHash>(ptr),
+
+        _ => panic!("Could not drop unknown type {:?}", type_str),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn _rgb_free_internal_array(arr: *mut libc::c_void, type_str: *const libc::c_char) {
+    let type_str = CStr::from_ptr(type_str).to_str().unwrap();
+
+    match type_str {
+        "struct rgb_allocated_array_rgb_contract" => rust_drop_array::<CRgbContract>(arr),
+        "struct rgb_allocated_array_rgb_proof" => rust_drop_array::<CRgbProof>(arr),
+        "struct rgb_allocated_array_rgb_needed_tx" => rust_drop_array::<CRgbNeededTx>(arr),
+        "struct rgb_allocated_array_rgb_needed_tx_map" => rust_drop_array::<HashMap<NeededTx, Transaction>>(arr),
+        "struct rgb_allocated_array_rgb_sha256d" => rust_drop_array::<Sha256dHash>(arr),
+        "struct rgb_allocated_array_uint8_t" => rust_drop_array::<u8>(arr),
+
+        _ => panic!("Could not drop unknown type {:?}", type_str),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod needed_txs_map;
 
 #[derive(Debug)]
 #[repr(C)]
-pub struct CRgbAllocatedBox<T> {
+pub struct CRgbAllocatedArray<T> {
     pub ptr: Box<[T]>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod c_bitcoin;
 pub mod contract;
 pub mod proof;
 pub mod needed_txs_map;
+pub mod free;
 
 #[derive(Debug)]
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,12 @@ pub struct CRgbAllocatedArray<T> {
 
 #[derive(Debug)]
 #[repr(C)]
+pub struct CRgbAllocatedPtr<T> {
+    pub ptr: Box<[T; 1]>,
+}
+
+#[derive(Debug)]
+#[repr(C)]
 pub enum CRgbNeededTx {
     // TODO: impl WrapperOf
     FromTXID(Sha256dHash, u32),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,20 +4,28 @@ extern crate bitcoin;
 extern crate libc;
 extern crate rgb;
 
+use std::slice;
+
 use bitcoin::Transaction;
 use bitcoin::util::hash::Sha256dHash;
+use rgb::traits::NeededTx;
+
 use c_bitcoin::CRgbOutPoint;
 use contract::CRgbContract;
 use generics::WrapperOf;
 use proof::CRgbProof;
-use rgb::traits::NeededTx;
-use std::slice;
 
 pub mod generics;
 pub mod c_bitcoin;
 pub mod contract;
 pub mod proof;
 pub mod needed_txs_map;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct CRgbAllocatedBox<T> {
+    pub ptr: Box<[T]>,
+}
 
 #[derive(Debug)]
 #[repr(C)]

--- a/src/needed_txs_map.rs
+++ b/src/needed_txs_map.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use bitcoin::Transaction;
 use rgb::traits::NeededTx;
 
-use ::{CRgbAllocatedBox, CRgbNeededTx};
+use ::{CRgbAllocatedArray, CRgbNeededTx};
 use CRgbSerializedTx;
 use generics::WrapperOf;
 
 #[no_mangle]
-pub extern "C" fn rgb_init_needed_tx_map() -> CRgbAllocatedBox<HashMap<NeededTx, Transaction>> {
-    CRgbAllocatedBox {
+pub extern "C" fn rgb_init_needed_tx_map() -> CRgbAllocatedArray<HashMap<NeededTx, Transaction>> {
+    CRgbAllocatedArray {
         ptr: vec![HashMap::new()].into_boxed_slice()
     }
 }

--- a/src/needed_txs_map.rs
+++ b/src/needed_txs_map.rs
@@ -1,16 +1,17 @@
+use std::collections::HashMap;
+
 use bitcoin::Transaction;
-use CRgbNeededTx;
+use rgb::traits::NeededTx;
+
+use ::{CRgbAllocatedBox, CRgbNeededTx};
 use CRgbSerializedTx;
 use generics::WrapperOf;
-use rgb::traits::NeededTx;
-use std::collections::HashMap;
-use std::mem;
 
 #[no_mangle]
-pub extern "C" fn rgb_init_needed_tx_map(map: &mut Box<HashMap<NeededTx, Transaction>>) {
-    let mut new_map = Box::new(HashMap::new());
-    mem::swap(&mut new_map, &mut *map);
-    mem::forget(new_map);
+pub extern "C" fn rgb_init_needed_tx_map() -> CRgbAllocatedBox<HashMap<NeededTx, Transaction>> {
+    CRgbAllocatedBox {
+        ptr: vec![HashMap::new()].into_boxed_slice()
+    }
 }
 
 #[no_mangle]

--- a/src/needed_txs_map.rs
+++ b/src/needed_txs_map.rs
@@ -4,13 +4,13 @@ use bitcoin::Transaction;
 use rgb::traits::NeededTx;
 
 use ::{CRgbAllocatedArray, CRgbNeededTx};
-use CRgbSerializedTx;
+use ::{CRgbAllocatedPtr, CRgbSerializedTx};
 use generics::WrapperOf;
 
 #[no_mangle]
-pub extern "C" fn rgb_init_needed_tx_map() -> CRgbAllocatedArray<HashMap<NeededTx, Transaction>> {
-    CRgbAllocatedArray {
-        ptr: vec![HashMap::new()].into_boxed_slice()
+pub extern "C" fn rgb_init_needed_tx_map() -> CRgbAllocatedPtr<HashMap<NeededTx, Transaction>> {
+    CRgbAllocatedPtr {
+        ptr: Box::new([HashMap::new()])
     }
 }
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -9,7 +9,7 @@ use rgb::output_entry::OutputEntry;
 use rgb::proof::Proof;
 use rgb::traits::Verify;
 
-use ::{CRgbAllocatedBox, CRgbNeededTx};
+use ::{CRgbAllocatedArray, CRgbNeededTx};
 use c_bitcoin::CRgbOutPoint;
 use contract::CRgbContract;
 use generics::WrapperOf;
@@ -158,20 +158,20 @@ pub extern "C" fn rgb_proof_is_root_proof(proof: &CRgbProof) -> u8 {
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_proof_get_needed_txs(proof: &CRgbProof) -> CRgbAllocatedBox<CRgbNeededTx> {
+pub extern "C" fn rgb_proof_get_needed_txs(proof: &CRgbProof) -> CRgbAllocatedArray<CRgbNeededTx> {
     let needed_txs_native = proof.decode().get_needed_txs();
     let needed_txs_vec: Vec<CRgbNeededTx> = needed_txs_native
         .iter()
         .map(|ref x| CRgbNeededTx::encode(x))
         .collect();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: needed_txs_vec.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_proof_get_expected_script(proof: &CRgbProof) -> CRgbAllocatedBox<u8> {
+pub extern "C" fn rgb_proof_get_expected_script(proof: &CRgbProof) -> CRgbAllocatedArray<u8> {
     use bitcoin::network::serialize::serialize;
 
     let script = proof.decode().get_expected_script();
@@ -185,24 +185,24 @@ pub extern "C" fn rgb_proof_get_expected_script(proof: &CRgbProof) -> CRgbAlloca
        field will remain */
     encoded.remove(0);
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: encoded.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_proof_serialize(proof: &CRgbProof) -> CRgbAllocatedBox<u8> {
+pub extern "C" fn rgb_proof_serialize(proof: &CRgbProof) -> CRgbAllocatedArray<u8> {
     use bitcoin::network::serialize::serialize;
 
     let encoded: Vec<u8> = serialize(&proof.decode()).unwrap();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: encoded.into_boxed_slice()
     }
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRgbAllocatedBox<CRgbProof> {
+pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRgbAllocatedArray<CRgbProof> {
     use bitcoin::network::serialize::deserialize;
 
     let sized_slice = unsafe { slice::from_raw_parts(buffer, len as usize) };
@@ -210,7 +210,7 @@ pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRg
 
     let native_proof = deserialize(&encoded).unwrap();
 
-    CRgbAllocatedBox {
+    CRgbAllocatedArray {
         ptr: vec![CRgbProof::encode(&native_proof)].into_boxed_slice()
     }
 }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -12,6 +12,7 @@ use rgb::traits::Verify;
 use ::{CRgbAllocatedArray, CRgbNeededTx};
 use c_bitcoin::CRgbOutPoint;
 use contract::CRgbContract;
+use CRgbAllocatedPtr;
 use generics::WrapperOf;
 
 #[derive(Debug)]
@@ -202,7 +203,7 @@ pub extern "C" fn rgb_proof_serialize(proof: &CRgbProof) -> CRgbAllocatedArray<u
 }
 
 #[no_mangle]
-pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRgbAllocatedArray<CRgbProof> {
+pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRgbAllocatedPtr<CRgbProof> {
     use bitcoin::network::serialize::deserialize;
 
     let sized_slice = unsafe { slice::from_raw_parts(buffer, len as usize) };
@@ -210,7 +211,7 @@ pub extern "C" fn rgb_proof_deserialize(buffer: *const c_uchar, len: u32) -> CRg
 
     let native_proof = deserialize(&encoded).unwrap();
 
-    CRgbAllocatedArray {
-        ptr: vec![CRgbProof::encode(&native_proof)].into_boxed_slice()
+    CRgbAllocatedPtr {
+        ptr: Box::new([CRgbProof::encode(&native_proof)])
     }
 }


### PR DESCRIPTION
Big changes to memory management

This is the first step towards a safer memory management: stuff allocated by Rust are returned wrapped into a particular kind of object, so that it can later (with some other updates that will follow) be dropped by Rust.

No more pointer-of-pointer getting dereferenced and assigned.

At the moment everything is returned in a slice because otherwise there would be issues with non-typed structs. Hopefully with some extra mind-twisting macros we can remove the `rgb_as_ptr` C macro and directly return ptrs.