### PR TITLE
rgb_example_util.c: missing stdint.h

### DIFF
--- a/examples/lib/rgb_example_util.c
+++ b/examples/lib/rgb_example_util.c
@@ -2,6 +2,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <assert.h>
  
 #include "rgb_example_util.h"


### PR DESCRIPTION
necessary on Ubuntu, not on macOS